### PR TITLE
Remove a type signature of 'withBDD'.

### DIFF
--- a/hBDD-CUDD/Data/Boolean/CUDD.chs
+++ b/hBDD-CUDD/Data/Boolean/CUDD.chs
@@ -113,7 +113,6 @@ cFromEnum  = fromIntegral . fromEnum
 -- | The abstract type of BDDs.
 {#pointer *DdNode as BDD foreign newtype#}
 
-withBDD :: BDD -> (Ptr BDD -> IO a) -> IO a
 {-# INLINE withBDD #-}
 
 -- BDDs are just pointers, so there's no work to do when we @deepseq@ them.


### PR DESCRIPTION
This removes a type signature of 'withBDD' in CUDD.chs, because recent version of c2hs automatically generate it and duplication of type signatures cause following compilation error.

```
[1 of 1] Compiling Data.Boolean.CUDD ( dist/build/Data/Boolean/CUDD.hs, dist/build/Data/Boolean/CUDD.o )

Data/Boolean/CUDD.chs:116:1:
    Duplicate type signatures for ‘withBDD’
    at Data/Boolean/CUDD.chs:115:1-7
       Data/Boolean/CUDD.chs:116:1-7
```

The problem is first reported at https://github.com/peteg/hBDD/issues/1 .
